### PR TITLE
psu load batch and load titles

### DIFF
--- a/bin/startup
+++ b/bin/startup
@@ -7,9 +7,9 @@ if [ -f /vault/secrets/config ]; then
 fi
 
 python manage.py create_collection
-
 python manage.py setup_index
 python manage.py migrate
+python manage.py loaddata core/fixtures/psu_awardees.json
 
 # copy static assets into the shared volume that the nginx-sidecar runs 
 cp -rf static/compiled data/word_coordinates/static

--- a/psu-custom/core/management/commands/psu_load_batch.py
+++ b/psu-custom/core/management/commands/psu_load_batch.py
@@ -1,0 +1,45 @@
+import os
+import logging
+
+from optparse import make_option
+from ssl import AlertDescription
+
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from django_q.tasks import async_task
+
+from core.batch_loader import BatchLoader, BatchLoaderException
+from core.management.commands import configure_logging
+from core.models import Batch
+    
+configure_logging('load_batch_logging.config', 
+                  'load_batch_%s.log' % os.getpid())
+
+LOGGER = logging.getLogger(__name__)
+
+
+def load_batch(batch_path):
+    loader = BatchLoader(process_coordinates=True, process_ocr=True)
+    try:
+        batch = loader.load_batch(batch_path)
+    except BatchLoaderException as e:
+        LOGGER.exception(e)
+        raise CommandError("Batch load failed. See logs/load_batch_#.log")
+
+
+class Command(BaseCommand):
+    help = """
+    This command loads the metadata and pages associated with a batch into a
+    database and search index. It may take up to several hours to complete,
+    depending on the batch size and machine.
+    """
+
+    def handle(self, *args, **options):
+        already_loaded_batches = [ b.name for b in Batch.objects.all() ]
+        batches  = [d for d in os.listdir('data/batches') if d.startswith("batch_") and d not in already_loaded_batches]
+
+        for batch in batches:
+            LOGGER.info(f"loading batch {batch}")
+            batch_path = "/open-oni/data/batches/" + batch
+            async_task("core.management.commands.load_batch_async.load_batch", batch_path)

--- a/psu-custom/core/management/commands/psu_load_titles.py
+++ b/psu-custom/core/management/commands/psu_load_titles.py
@@ -1,0 +1,32 @@
+import logging
+
+import os
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from django.core.management import call_command
+
+from core import title_loader
+from core import solr_index
+from core.models import Title
+from core.management.commands import configure_logging
+import os
+
+configure_logging('load_titles_logging.config', 'load_titles.log')
+_logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = """
+    Loads titles into Open ONI from a single file or a path containing multiple
+    files.  All files must contain valid MARC XML.
+    """
+    def handle(self, *args, **options):
+        #TODO add this as an argument with default
+        path = "/open-oni/data/batches/marc"
+        for root, directories, file in os.walk(path):
+            for file in file:
+                if(file == "marc.xml"):
+                    print(os.path.join(root,file))
+                    call_command("load_titles", os.path.join(root,file))


### PR DESCRIPTION
adds `psu_load_batch` it does a diff of batches in the system, and batches on disk, and loads batches on disk that are not in the system 

adds `psu_load_titles` it loads all the marc files from `/open-oni/data/batches/marc` and runs the load_title command on them. 

I manually placed the marc directory from pcd, the thought is the thing that 'primes' the share can also 'prime' the marc directory. 

I need to wire all this together yet, but the meat is there. 