### PR TITLE
load titles

### DIFF
--- a/psu-custom/core/management/commands/psu_load_batch.py
+++ b/psu-custom/core/management/commands/psu_load_batch.py
@@ -3,29 +3,36 @@ import logging
 
 from optparse import make_option
 from ssl import AlertDescription
+from lxml import etree
 
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
+from django.core.management import call_command
 
 from django_q.tasks import async_task
+from django_q.models import Task
 
 from core.batch_loader import BatchLoader, BatchLoaderException
 from core.management.commands import configure_logging
 from core.models import Batch
-    
-configure_logging('load_batch_logging.config', 
-                  'load_batch_%s.log' % os.getpid())
+
+configure_logging("load_batch_logging.config", "load_batch_%s.log" % os.getpid())
 
 LOGGER = logging.getLogger(__name__)
 
-
-def load_batch(batch_path):
-    loader = BatchLoader(process_coordinates=True, process_ocr=True)
-    try:
-        batch = loader.load_batch(batch_path)
-    except BatchLoaderException as e:
-        LOGGER.exception(e)
-        raise CommandError("Batch load failed. See logs/load_batch_#.log")
+def load_our_lccn(batch_xml):
+    our_lccns = os.listdir("/open-oni/data/batches/marc")
+    tree = etree.parse(batch_xml).getroot()
+    lccns = [s.attrib["lccn"] for s in tree if s.attrib.get("lccn", False)]
+    lccns = list(set(lccns))
+    for lccn in lccns:
+        if lccn in our_lccns:
+            marc_xml = f"/open-oni/data/batches/marc/{lccn}/marc.xml"
+            if os.path.isfile(marc_xml):
+                LOGGER.info(f"loading title for {lccn}")
+                call_command("load_titles", marc_xml, "--skip-index")
+            else:
+                LOGGER.error(f"we think we have marc data for {lccn} but we do not")
 
 
 class Command(BaseCommand):
@@ -36,22 +43,40 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-        already_loaded_batches = [ b.name for b in Batch.objects.all() ]
-        batches_env = os.getenv('BATCHES_ENV', 'dev')
+        successful_tasks = Task.objects.filter(success=True)
+        already_loaded_batches = [
+            s.args[0].rstrip("/").split("/")[-1] for s in successful_tasks
+        ]
+        batches_env = os.getenv("BATCHES_ENV", "dev")
         batches_file = f"data/batches/batches-{batches_env}.txt"
         if os.path.isfile(batches_file):
-            with open(batches_file, 'r') as f:
+            with open(batches_file, "r") as f:
                 batches = [line.strip() for line in f.readlines() if line.strip()]
         else:
             raise ValueError(f"file {batches_file} does not exist")
 
-        batches_to_load = [batch for batch in batches if batch not in already_loaded_batches]
+        batches_to_load = [
+            batch for batch in batches if batch not in already_loaded_batches
+        ]
         LOGGER.info(f"found {len(batches_to_load)} batches to load")
 
         for batch in batches_to_load:
             batch_path = f"/open-oni/data/batches/{batch}"
+            batch_xml = f"{batch_path}/data/BATCH.xml"
+
+            # If we have custom marc.xml for a given lccn, we load it before calling the load_batch command
+            if os.path.isfile(batch_xml):
+                load_our_lccn(batch_xml)
+            if os.path.isfile(batch_xml.lower()):
+                load_our_lccn(batch_xml.lower())
+
             if os.path.isdir(batch_path):
                 LOGGER.info(f"loading batch {batch}")
-                async_task("core.management.commands.load_batch_async.load_batch", batch_path)
+                async_task(
+                    "core.management.commands.load_batch_async.load_batch", batch_path
+                )
             else:
-                LOGGER.info(f"batch {batch} not found")
+                LOGGER.error(f"batch {batch} not found")
+
+        # since we skip index of titles above, we index here
+        call_command("index_titles")

--- a/psu-custom/core/management/commands/psu_rerun_failed.py
+++ b/psu-custom/core/management/commands/psu_rerun_failed.py
@@ -1,0 +1,44 @@
+import os
+import logging
+
+from optparse import make_option
+from ssl import AlertDescription
+
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from django_q.tasks import async_task
+from django_q.models import Task
+
+from core.batch_loader import BatchLoader, BatchLoaderException
+from core.management.commands import configure_logging
+from core.models import Batch
+    
+configure_logging('load_batch_logging.config', 
+                  'load_batch_%s.log' % os.getpid())
+
+LOGGER = logging.getLogger(__name__)
+
+
+def load_batch(batch_path):
+    loader = BatchLoader(process_coordinates=True, process_ocr=True)
+    try:
+        batch = loader.load_batch(batch_path)
+    except BatchLoaderException as e:
+        LOGGER.exception(e)
+        raise CommandError("Batch load failed. See logs/load_batch_#.log")
+
+
+class Command(BaseCommand):
+    help = """
+    Looks at failed tasks, reruns the job, and removes the failed item from
+    the database
+    """
+
+    def handle(self, *args, **options):
+        failed_tasks = Task.objects.filter(success=False)
+        for task in failed_tasks:
+            print(f"requeuing {task.args[0]}")
+            async_task("core.management.commands.load_batch_async.load_batch", task.args[0])
+            print(f"removing failed task from failed queue")
+            task.delete()


### PR DESCRIPTION
- rerun failed jobs
- call "load_title" for any title we have as a "custom" title 
- `Batch.objects.all()` isn't a great representation of batches in the system, if a batch failed, or got in a half open state it would think it was successful. 
- looks at all successful tasks in the Tasks table, and uses that as a guide for batches already loaded.