### PR TITLE
preview/migrate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY bin/startup /usr/local/bin/startup
 COPY bin/migrate /usr/local/bin/migrate
 RUN chmod +x /usr/local/bin/startup
+RUN chmod +x /usr/local/bin/migrate
 
 USER app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   rm -rf /var/lib/apt/lists/* 
 
 COPY bin/startup /usr/local/bin/startup
+COPY bin/migrate /usr/local/bin/migrate
 RUN chmod +x /usr/local/bin/startup
 
 USER app
@@ -48,6 +49,7 @@ RUN pip install --no-cache-dir -r psu-requirements.txt --user
 COPY --chown=app open-oni /open-oni
 COPY --chown=app config/settings_local.py /open-oni/onisite
 COPY --chown=app config/urls.py /open-oni/onisite
+COPY --chown=app config/gunicorn.conf.py /open-oni/gunicorn.conf.py
 COPY --chown=app themes /open-oni/themes
 
 ADD --chown=app psu-custom/ /open-oni

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN pip install --no-cache-dir -r psu-requirements.txt --user
 COPY --chown=app open-oni /open-oni
 COPY --chown=app config/settings_local.py /open-oni/onisite
 COPY --chown=app config/urls.py /open-oni/onisite
-COPY --chown=app config/gunicorn.conf.py /open-oni/gunicorn.conf.py
 COPY --chown=app themes /open-oni/themes
 
 ADD --chown=app psu-custom/ /open-oni

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,16 @@
+#!/bin/bash
+# run migration scripts
+set -e
+
+if [ -f /vault/secrets/config ]; then 
+  . /vault/secrets/config
+fi
+
+python manage.py create_collection
+python manage.py setup_index
+python manage.py migrate
+python manage.py loaddata core/fixtures/psu_awardees.json
+
+# copy static assets into the shared volume that the nginx-sidecar runs 
+mkdir -p data/word_coordinates/static
+cp -rf static/compiled/* data/word_coordinates/static

--- a/bin/startup
+++ b/bin/startup
@@ -6,13 +6,4 @@ if [ -f /vault/secrets/config ]; then
   . /vault/secrets/config
 fi
 
-python manage.py create_collection
-python manage.py setup_index
-python manage.py migrate
-python manage.py loaddata core/fixtures/psu_awardees.json
-
-# copy static assets into the shared volume that the nginx-sidecar runs 
-mkdir -p data/word_coordinates/static
-cp -rf static/compiled/* data/word_coordinates/static
-
 gunicorn onisite.wsgi -b 0.0.0.0


### PR DESCRIPTION
- split out migration and startup
- make executable


splits out migrate, and startup. all the 'migration' tasks, like copying assets, creating the collection and updating the database happens as a job that runs as a hook, this allows the pod to just startup and wait for it's resources to be healthy

